### PR TITLE
Incompatibility with ATVocabularyManager

### DIFF
--- a/eea/faceted/vocabularies/portal.py
+++ b/eea/faceted/vocabularies/portal.py
@@ -26,9 +26,10 @@ class PortalVocabulariesVocabulary(object):
             vocabularies = vtool.objectValues()
             res.extend([(term.getId(), term.title_or_id())
                         for term in vocabularies])
+        atvocabulary_ids = [elem[0] for elem in res]
 
         factories = getUtilitiesFor(IVocabularyFactory)
-        res.extend([(factory[0], factory[0]) for factory in factories if factory[0] not in [elem[0] for elem in res]])
+        res.extend([(factory[0], factory[0]) for factory in factories if factory[0] not in atvocabulary_ids])
 
         res.sort(key=operator.itemgetter(1), cmp=compare)
         res.insert(0, ('', ''))


### PR DESCRIPTION
I found a problem with this package when ATVocabularyManager is installed.

If the vocabulary defined through ATVocabularyManager is also registered as an IVocabularyFactory utility, the eea.facetednavigation configuration breaks due to duplicate vocabulary name.

You commonly get this exception:

```
   - URL: file:/Users/luca/Library/Buildout/eggs/Products.Archetypes-1.7.12-py2.6.egg/Products/Archetypes/skins/archetypes/widgets/selection.pt
   - Line 36, Column 12
   - Expression: <PythonExpr field.Vocabulary(context)>
   - Names:
      {'args': (),
       'container': <ATFolder at /ArchivioFotografico/cartella>,
       'context': <ATFolder at /ArchivioFotografico/cartella>,
       'default': <object object at 0x100416b30>,
       'here': <ATFolder at /ArchivioFotografico/cartella>,
       'loop': {},
       'nothing': None,
       'options': {},
       'repeat': <Products.PageTemplates.Expressions.SafeMapping object at 0x10a75f2b8>,
       'request': <HTTPRequest, URL=http://localhost:8080/ArchivioFotografico/cartella/configure_faceted.html>,
       'root': <Application at >,
       'template': <Products.Five.browser.pagetemplatefile.ViewPageTemplateFile object at 0x107ad2a10>,
       'traverse_subpath': [],
       'user': <PropertiedUser 'admin'>,
       'view': <eea.facetednavigation.widgets.schema.Schema object at 0x10a391d90>,
       'views': <Products.Five.browser.pagetemplatefile.ViewMapper object at 0x10a391fd0>}
  Module Products.PageTemplates.ZRPythonExpr, line 48, in __call__
   - __traceback_info__: field.Vocabulary(context)
  Module PythonExpr, line 1, in <expression>
  Module Products.Archetypes.Field, line 469, in Vocabulary
  Module eea.faceted.vocabularies.portal, line 37, in __call__
  Module zope.schema.vocabulary, line 64, in __init__
ValueError: term values must be unique: u'composizioni'
```

With this fix I check before if the vocabulary name is already registered.
