### PR TITLE
Add vocabulary listing autocomplete sources for eea.facetednavigation autocomplete widget

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -3,6 +3,9 @@ Changelog
 
 5.3.dev0 - (unreleased)
 -----------------------
+* Feature: Added AutocompleteVocabulary listing autocomplete suggestion views
+  for the autocomplete widget.
+  [sdelcourt]
 
 5.2 - (2015-08-18)
 ------------------

--- a/eea/faceted/vocabularies/README.txt
+++ b/eea/faceted/vocabularies/README.txt
@@ -64,6 +64,6 @@ eea.faceted.vocabularies.AutocompleteVocabularies
 ---------------------------------------
 Possible autocomplete suggestions views
 
-    >>> voc = getUtility(IVocabularyFactory, 'eea.faceted.vocabularies.AutocompleteVocabularies')
+    >>> voc = getUtility(IVocabularyFactory, 'eea.faceted.vocabularies.AutocompleteViews')
     >>> voc
-    <eea.faceted.vocabularies.autocomplete.AutocompleteVocabularies object at ...>
+    <eea.faceted.vocabularies.autocomplete.AutocompleteVocabulary object at ...>

--- a/eea/faceted/vocabularies/README.txt
+++ b/eea/faceted/vocabularies/README.txt
@@ -60,9 +60,9 @@ Catalog indexes including sorting ones
     >>> voc
     <eea.faceted.vocabularies.catalog.SortingCatalogIndexesVocabulary object at ...>
 
-eea.faceted.vocabularies.SortingCatalog
+eea.faceted.vocabularies.AutocompleteVocabularies
 ---------------------------------------
-Catalog indexes including sorting ones
+Possible autocomplete suggestions views
 
     >>> voc = getUtility(IVocabularyFactory, 'eea.faceted.vocabularies.AutocompleteVocabularies')
     >>> voc

--- a/eea/faceted/vocabularies/README.txt
+++ b/eea/faceted/vocabularies/README.txt
@@ -59,3 +59,11 @@ Catalog indexes including sorting ones
     >>> voc = getUtility(IVocabularyFactory, 'eea.faceted.vocabularies.SortingCatalogIndexes')
     >>> voc
     <eea.faceted.vocabularies.catalog.SortingCatalogIndexesVocabulary object at ...>
+
+eea.faceted.vocabularies.SortingCatalog
+---------------------------------------
+Catalog indexes including sorting ones
+
+    >>> voc = getUtility(IVocabularyFactory, 'eea.faceted.vocabularies.AutocompleteVocabularies')
+    >>> voc
+    <eea.faceted.vocabularies.autocomplete.AutocompleteVocabularies object at ...>

--- a/eea/faceted/vocabularies/autocomplete.py
+++ b/eea/faceted/vocabularies/autocomplete.py
@@ -1,4 +1,4 @@
-""" Autocomplete widget specific vocabularies
+""" Autocomplete widget specific vocabulary
 """
 from eea.faceted.vocabularies.utils import IVocabularyFactory
 
@@ -12,7 +12,7 @@ from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
 
 
-class AutocompleteVocabularies(object):
+class AutocompleteVocabulary(object):
     """
     """
     implements(IVocabularyFactory)

--- a/eea/faceted/vocabularies/autocomplete.py
+++ b/eea/faceted/vocabularies/autocomplete.py
@@ -1,0 +1,42 @@
+""" Autocomplete widget specific vocabularies
+"""
+from eea.faceted.vocabularies.utils import IVocabularyFactory
+
+from zope.component import getAdapters
+
+from zope.interface import Attribute
+from zope.interface import Interface
+from zope.interface import implements
+
+from zope.schema.vocabulary import SimpleTerm
+from zope.schema.vocabulary import SimpleVocabulary
+
+
+class AutocompleteVocabularies(object):
+    """
+    """
+    implements(IVocabularyFactory)
+
+    def __call__(self, context):
+        """
+        """
+        factories = getAdapters(
+            (context, context.REQUEST),
+            IAutocompleteSuggest
+        )
+        terms = [SimpleTerm(f[0], f[0], getattr(f[1], 'label', f[0])) for f in factories]
+        return SimpleVocabulary(terms)
+
+
+class IAutocompleteSuggest(Interface):
+    """
+    Interface for views generating autocomplete suggestions vocabulary.
+    """
+
+    label = Attribute("Suggestions name")
+
+    def __call__(self):
+        """
+        Should return a json array of value/label objects.
+        eg: [{'value':'42', 'label:'Answer to some question..'}, ...]
+        """

--- a/eea/faceted/vocabularies/configure.zcml
+++ b/eea/faceted/vocabularies/configure.zcml
@@ -8,8 +8,8 @@
   <i18n:registerTranslations directory="locales" />
 
   <utility
-    factory=".autocomplete.AutocompleteVocabularies"
-    name="eea.faceted.vocabularies.AutocompleteVocabularies"
+    factory=".autocomplete.AutocompleteVocabulary"
+    name="eea.faceted.vocabularies.AutocompleteViews"
     />
 
   <utility

--- a/eea/faceted/vocabularies/configure.zcml
+++ b/eea/faceted/vocabularies/configure.zcml
@@ -8,6 +8,11 @@
   <i18n:registerTranslations directory="locales" />
 
   <utility
+    factory=".autocomplete.AutocompleteVocabularies"
+    name="eea.faceted.vocabularies.AutocompleteVocabularies"
+    />
+
+  <utility
     factory=".catalog.ObjectProvidesVocabulary"
     name="eea.faceted.vocabularies.ObjectProvides"
     />


### PR DESCRIPTION
Hi, @tomgross, @avoinea 

I want to be able to choose the view to call to provide vocabulary suggestion for the autocomplete widget of eea.facetednavigation (which is, for now, a solr autocompletion). 
To do this I:
- added a field 'autocomplete_view' on the autocomplete widget to be able to select the view providing suggestions.
- registered a new vocabulary in this product listing available autocomplete suggestions views (it looks for adapters providing IAutocompleteSuggest interface).
- finally registered the solr completion view as an adapter providing  IAutocompleteSuggest so the solr autocomplete is still the default for the autocomplete widget but it allows me to register my own views and select them if I want to.

@tomgross 
I would like to know if you're ok with my changes.

Regards,

Simon